### PR TITLE
Add /add_job endpoint which takes a POST containing just a audio url

### DIFF
--- a/main.go
+++ b/main.go
@@ -36,17 +36,17 @@ func helloHandler(w http.ResponseWriter, r *http.Request) {
 // initiateTranscriptionJobHandle takes a POST request containing a json object,
 // decodes it into an audioData struct, and returns the struct json-encoded.
 func initiateTranscriptionJobHandler(w http.ResponseWriter, r *http.Request) {
-	var d transcriptionJobData
+	var jsonData transcriptionJobData
 
 	// unmarshal from the response body directly into our struct
-	if err := json.NewDecoder(r.Body).Decode(&d); err != nil {
+	if err := json.NewDecoder(r.Body).Decode(&jsonData); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 
 	// return the struct encoded as json
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
-	json.NewEncoder(w).Encode(d)
+	json.NewEncoder(w).Encode(jsonData)
 }
 
 type transcriptionJobData struct {

--- a/main.go
+++ b/main.go
@@ -5,12 +5,14 @@ import (
 	"net/http"
 	_ "net/http/pprof" // import for side effects
 
+	"encoding/json"
 	"github.com/gorilla/mux"
 )
 
 func main() {
 	r := mux.NewRouter()
 	r.HandleFunc("/hello/{name}", helloHandler)
+	r.HandleFunc("/add_job", jobHandler)
 
 	http.Handle("/", r)
 	http.ListenAndServe(":8080", nil)
@@ -19,4 +21,20 @@ func main() {
 func helloHandler(w http.ResponseWriter, r *http.Request) {
 	args := mux.Vars(r)
 	fmt.Fprintf(w, "Hello %s!", args["name"])
+}
+
+func jobHandler(w http.ResponseWriter, r *http.Request) {
+	var d audioData
+
+	if err := json.NewDecoder(r.Body).Decode(&d); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	json.NewEncoder(w).Encode(d)
+}
+
+type audioData struct {
+	AudioURL string `json:"audioURL"`
 }

--- a/main.go
+++ b/main.go
@@ -12,7 +12,7 @@ import (
 func main() {
 	r := mux.NewRouter()
 	r.HandleFunc("/hello/{name}", helloHandler)
-	r.HandleFunc("/add_job", jobHandler)
+	r.HandleFunc("/add_job", initiateTranscriptionJobHandler)
 
 	http.Handle("/", r)
 	http.ListenAndServe(":8080", nil)
@@ -23,18 +23,22 @@ func helloHandler(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprintf(w, "Hello %s!", args["name"])
 }
 
-func jobHandler(w http.ResponseWriter, r *http.Request) {
-	var d audioData
+// initiateTranscriptionJobHandle takes a POST request containing a json object,
+// decodes it into an audioData struct, and returns the struct json-encoded.
+func initiateTranscriptionJobHandler(w http.ResponseWriter, r *http.Request) {
+	var d transcriptionJobData
 
+	// unmarshal from the response body directly into our struct
 	if err := json.NewDecoder(r.Body).Decode(&d); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 
+	// return the struct encoded as json
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
 	json.NewEncoder(w).Encode(d)
 }
 
-type audioData struct {
+type transcriptionJobData struct {
 	AudioURL string `json:"audioURL"`
 }

--- a/main.go
+++ b/main.go
@@ -34,19 +34,17 @@ func helloHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 // initiateTranscriptionJobHandle takes a POST request containing a json object,
-// decodes it into an audioData struct, and returns the struct json-encoded.
+// decodes it into an audioData struct, and returns appropriate message.
 func initiateTranscriptionJobHandler(w http.ResponseWriter, r *http.Request) {
 	var jsonData transcriptionJobData
 
 	// unmarshal from the response body directly into our struct
 	if err := json.NewDecoder(r.Body).Decode(&jsonData); err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 
-	// return the struct encoded as json
-	w.Header().Set("Content-Type", "application/json; charset=utf-8")
-	json.NewEncoder(w).Encode(jsonData)
+	fmt.Fprintf(w, "Accepted!")
 }
 
 type transcriptionJobData struct {

--- a/main.go
+++ b/main.go
@@ -1,11 +1,11 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 	_ "net/http/pprof" // import for side effects
 
-	"encoding/json"
 	"github.com/gorilla/mux"
 )
 


### PR DESCRIPTION
r @sandlerben 
- expects a json string which looks like this
  `{
  "audioURL": "https://sound.com/random.mp3"
  }`
- responds with a 200 OK for now
- added `audioData` struct that unmarshalls json; added `json` package

<img width="568" alt="screen shot 2016-02-13 at 9 31 34 am" src="https://cloud.githubusercontent.com/assets/4250521/13028168/c8e1a42c-d234-11e5-877c-588de4332ab6.png">

Run with command:
`curl -X POST -d "{\"audioURL\": \"https://sound.com/random.mp3\"}"  http://localhost:8080/add_job`
