### PR TITLE
Annotate errors with stack trace information

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"github.com/BurntSushi/toml"
 	log "github.com/Sirupsen/logrus"
+	"github.com/juju/errors"
 )
 
 // Config is the application-wide config
@@ -16,10 +17,10 @@ func init() {
 	log.Infof("%+v", Config)
 }
 
-//parseConfigFile parses the specified file into a given struct
+// parseConfigFile parses the specified file into a given struct
 func parseConfigFile(config *AppConfig, filename string) error {
 	if _, err := toml.DecodeFile(filename, config); err != nil {
-		return err
+		return errors.Trace(err)
 	}
 	return nil
 }

--- a/tasks/tasks.go
+++ b/tasks/tasks.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	log "github.com/Sirupsen/logrus"
+	"github.com/juju/errors"
 )
 
 // Status is the status of the task.
@@ -115,7 +116,7 @@ func (ex *defaultExecuter) completeTask(id string, task func(string) error) {
 		ex.cMap.put(id, FAILURE)
 		log.WithFields(log.Fields{
 			"task":  id,
-			"error": err.Error(),
+			"error": errors.ErrorStack(err),
 		}).Error("Task failed")
 		return
 	}

--- a/transcription/ibm.go
+++ b/transcription/ibm.go
@@ -11,6 +11,7 @@ import (
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/gorilla/websocket"
+	"github.com/juju/errors"
 )
 
 // IBMResult is the result of an IBM transcription. See
@@ -45,7 +46,7 @@ func TranscribeWithIBM(filePath string, IBMUsername string, IBMPassword string) 
 	dialer := websocket.DefaultDialer
 	ws, _, err := dialer.Dial(url, header)
 	if err != nil {
-		return nil, err
+		return nil, errors.Trace(err)
 	}
 	defer ws.Close()
 
@@ -61,18 +62,18 @@ func TranscribeWithIBM(filePath string, IBMUsername string, IBMPassword string) 
 	}
 
 	if err = ws.WriteJSON(requestArgs); err != nil {
-		return nil, err
+		return nil, errors.Trace(err)
 	}
 	log.Debug("Starting transcription using IBM")
 
 	if err = uploadFileWithWebsocket(ws, filePath); err != nil {
-		return nil, err
+		return nil, errors.Trace(err)
 	}
 	log.Debugf("Successfully uploaded %s to IBM", filePath)
 
 	// write empty message to indicate end of uploading file
 	if err = ws.WriteMessage(websocket.BinaryMessage, []byte{}); err != nil {
-		return nil, err
+		return nil, errors.Trace(err)
 	}
 
 	// IBM must receive a message every 30 seconds or it will close the websocket.
@@ -85,7 +86,7 @@ func TranscribeWithIBM(filePath string, IBMUsername string, IBMPassword string) 
 	for {
 		err := ws.ReadJSON(&result)
 		if err != nil {
-			return nil, err
+			return nil, errors.Trace(err)
 		}
 		if len(result.Results) > 0 {
 			log.Debugf("IBM has returned results")
@@ -102,7 +103,7 @@ func basicAuth(username, password string) string {
 func uploadFileWithWebsocket(ws *websocket.Conn, filePath string) error {
 	f, err := os.Open(filePath)
 	if err != nil {
-		return err
+		return errors.Trace(err)
 	}
 
 	r := bufio.NewReader(f)
@@ -114,10 +115,10 @@ func uploadFileWithWebsocket(ws *websocket.Conn, filePath string) error {
 			break
 		}
 		if err != nil && err != io.EOF {
-			return err
+			return errors.Trace(err)
 		}
 		if err := ws.WriteMessage(websocket.BinaryMessage, buffer); err != nil {
-			return err
+			return errors.Trace(err)
 		}
 	}
 	return nil


### PR DESCRIPTION
Let's say I have some command-line application which also includes some utility function `foo`. If some error occurs within `foo`, the app should not ​_necessarily_​ be brought down, so `foo` doesn't panic. Rather, it returns the error. However, sometimes, an error from `foo` ​_should_​ panic the app. If that error makes its way up to the `main`, then let's say it will panic there.

This seems like a nice system except for one problem. By the time the panic happens in `main` all the context (e.g. call stack) of what caused the error in `foo` is gone. This makes a problem hard to debug without lots of print statements or a debugger.
